### PR TITLE
fix: falling speed not start from 0

### DIFF
--- a/Assets/Scripts/Player/Models/PlayerMovementState/PlayerMovementIdleState.cs
+++ b/Assets/Scripts/Player/Models/PlayerMovementState/PlayerMovementIdleState.cs
@@ -15,6 +15,7 @@ public class PlayerMovementIdleState : IPlayerMovementState
     public PlayerMovementIdleState(Player player, PlayerData playerData)
     {
         Player = player;
+        Player.Velocity.y = 0f;
         PlayerData = playerData;
         HandleAnimation();
     }

--- a/Assets/Scripts/Player/Models/PlayerMovementState/PlayerMovementRunningState.cs
+++ b/Assets/Scripts/Player/Models/PlayerMovementState/PlayerMovementRunningState.cs
@@ -15,6 +15,7 @@ public class PlayerMovementRunningState : IPlayerMovementState
     public PlayerMovementRunningState(Player player, PlayerData playerData)
     {
         Player = player;
+        Player.Velocity.y = 0f;
         PlayerData = playerData;
         HandleAnimation();
     }


### PR DESCRIPTION
# Fix falling speed not start from zero
In #47  this commit `137c2ee`, Yen removed the `ApplyGravity()`. We need to init the `Velocity.y  = 0` when we're in Idle or Running State so the transition to fall state will be free fall